### PR TITLE
List and load all available subtitles

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,7 +148,7 @@ def play(item):
                })
 
     li.setPath(item.stream_url())
-    li.setSubtitles([item.subtitles()])
+    li.setSubtitles(item.subtitles())
 
     xbmcplugin.setResolvedUrl(PLUGIN_HANDLE, succeeded=True, listitem=li)
 


### PR DESCRIPTION
Previous implementation handles only a single subtitle per video. The api url of the list of all subtitles is passed directly to kodi. The returned api contents doesn't match kodi's expectations, so it picks one url and downloads only that subtitle.

This implementation uses the put.io api to list all subtitles available for a video, then downloads them individually to a temporary directory before passing the file paths to kodi. Fixes #10.

Notes

- Allows selecting/changing subtitles while watching the video in kodi.
  - Passing the subtitle file url directly to kodi looks terrible in the kodi user interface for selecting subtitles, as the subtitle key part of the url is highly random.
  - The downloaded files, by contrast, use the original names. This looks much better, and is quite informative. It also allows kodi to detect subtitle language, and possibly variants for visually or hearing impared, so the user's subtitle (language) preferences in kodi can be applied.
- Supports user's custom subtitles uploaded via the put.io website.
  - Dragging and dropping the subtitle file in the video's directory perserves the original filename, using the button "add your own" does not -- it uses the video filename as a base.
  - Uploading custom subtitles may require refreshing the directory in kodi for them to be detected.
- Keeps only temporary subtitle files for the most recently watched video.
  - Always deletes any previous temporary subtitle files (for all videos) to not amass files, neither from duplicates of subtitles, every previously watched video, nor videos already deleted from put.io.
  - Downloads each subtitle each time a video is watched, as the files are tiny compared to the streamed video contents. By the way, the website player also downloads each subtitle each time a video is watched.
  - It's a simple implementation allowing access to user's custom subtitles, and any updated subtitles put.io receive from opensubtitles and other sources. Plus, it allows the user to simply try again, in case there was a download timeout or file corruption for some reason.
- There are subtitle filename collisions, even per video.
  - Am using the (truncated) subtitle key for subtitle uniqueness to not overwrite files with the same name during download.
  - The subtitle key is a bunch of base64 encoded bits. They are not deterministic, and may change even if the video id and each subtitle file contents stays the same. In fact, it seems they're freshly generated on each call to the api.

Improvements

- Parallelize subtitle downloads for some speed gains.
- Should ensure filename is clean (bad file extension, invalid characters, too long, empty/blank?), or clean it (worst case subtitle key plus file extension?). Perhaps `xbmc.makeLegalFilename(...)`, but didn't run into problems so far.
- Could keep temporary files longer as a cache.
  - Have a feeling it won't be worth the effort. Needs to detect deleted videos, newly added (possibly custom) subtitles, not fill up disk space (unlikely), and should anyways clean up the temporary directory periodically.
  - Test if it's a feasible improvement to store file HTTP etags (if available), or (at least) compare remote/local file sizes to avoid repeated downloads. With the current temporary file clearing "policy", it's only useful if the same video is watched twice in a row though.
- A default (selected) subtitle key is provided by the api, if matching the per-user subtitle language preferences on put.io.
  - Both language name (for humans) and language code (for computers) should be available in the response from put.io. Note that these api values seem to be affected by the previously mentioned per-user subtitle language preferences on put.io.
  - Kodi seems to detect subtitle language (name or code) by filename only, and seem to get it wrong sometimes. The filename `Just.do.it.srt` may yield `it` as the language code, `A.and.B.srt` may yield `and`.
  - Could use the subtitle language as detected by put.io to aid kodi's filename-based language detection, but prefer not to rename the file itself. This might be something to add to the add-on options.

Testing

- Developed and tested on raspbian running kodi v18.2.
- Mostly uses kodi's `special://` paths. This should mean that it's fairly cross-operating system compatible. Testing on other systems, in particular windows, would be good.
- Make sure to test using videos with a variety of languages available.

See

- https://github.com/putdotio/putio-kodi/pull/1
- https://kodi.wiki/view/Subtitles#Using_multi_language_subtitles
- https://kodi.wiki/view/Settings/Player/Language#Preferred_Subtitle_Language
- https://app.swaggerhub.com/apis-docs/putio/putio/2.6.3#/files/get_files__id__subtitles
- https://app.swaggerhub.com/apis-docs/putio/putio/2.6.3#/files/get_files__id__subtitles__key_
- https://codedocs.xyz/xbmc/xbmc/group__python__xbmcvfs.html
- https://codedocs.xyz/xbmc/xbmc/group__python__xbmc.html#gac40e0ecd5b1aa66a90c5c0918cd40491