### PR TITLE
Do not set both playcount and resumetime for finished videos

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,14 +85,16 @@ def populate_dir(files):
                 duration = metadata['duration']
                 video_offset = item.start_from if hasattr(item, 'start_from') else 0
 
+                # mark the video as watched if there is 5% progress left
+                video_finished = duration and ((duration - video_offset) <= (duration * 0.05))
+
                 if duration:
                     info_labels['duration'] = duration
-                    # mark the video as watched if there is %20 progress left
-                    if (duration - video_offset) <= (duration * 0.2):
-                        info_labels['playcount'] = 1
+                    if video_finished:
+                        info_labels['playcount'] = str(1)
 
                 # resumetime and totaltime are the undocumented properties to show resumable icon.
-                if video_offset:
+                if (not video_finished) and video_offset:
                     li.setProperty(key='resumetime', value=str(video_offset))
                 if duration:
                     li.setProperty(key='totaltime', value=str(duration))


### PR DESCRIPTION
- The viewing progress of a video is fetched from (and stored by) the Put.io API, and set per item in the Kodi interface. This allows items to be shown as unwatched/in progress/finished, as well as resuming viewing from where it was last stopped.
- With less than a few percent left to watch of a video, it should be marked as "finished". The logic already exists, but is functionally broken.
- When a video in Kodi is marked as both having been watched (`playcount` > 0) and having a `resumetime` (it is in progress of being watched), it is considered as being watched (rather than finished). Setting both properties with values from the Put.io API creates a "UI conflict".
- This commit changes `resumetime` to not be set when a video is considered "finished".
- To allow resuming further into a video, the "finished" percentage is reduced from 20% (12 minutes per hour) to 5% (3 m/h). This should cover regular use-cases while ignoring closing credits.
