### PR TITLE
Use Unicode for subtitle filenames

### DIFF
--- a/resources/lib/putio.py
+++ b/resources/lib/putio.py
@@ -211,7 +211,7 @@ class _File(_BaseResource):
         return subtitle_file_paths
 
     def _download_subtitle(self, url, special_path):
-        special_path_translated = xbmcvfs.translatePath(special_path)
+        special_path_translated = xbmcvfs.translatePath(special_path).encode()
         response = self.client.request(url, raw=True)
         with open(special_path_translated, 'wb') as f:
             for data in response.iter_content():


### PR DESCRIPTION
Fixes a crash for subtitle names with Unicode characters.

<details>

- Subtitles for Put.io videos are, if available, downloaded via the Put.io API.
  - The API subtitle names may contain characters from the Unicode character set.
  - The subtitle name from the API is used as the local filename, which Kodi then uses when displaying a list of available subtitles.
- Put.io's subtitle paths are handled as `special://temp` Kodi paths.
  - Special paths are recommended in Kodi, as they should help with cross-platform path-handling.
  - The special path handling in Kodi's `translatePath` function seems to return an ASCII-encoded string, also for Unicode input strings.
  - Characters from the extended (superset) Unicode charset are out of range for (7-bit) ASCII.
- The Put.io addon crashes for non-ASCII characters in the subtitle name.
  - Python's standard functions use "dynamic" path encoding handling, based on the input path charset.
  - Using a Unicode-encoded input path allows Unicode characters.
  - This fix (re)encodes the ASCII path returned from Kodi `translatePath` function as Unicode.
- This fix was developed on, and tested only on, a Debian machine running Kodi v20.1.

See

- https://en.wikipedia.org/wiki/ASCII
- https://en.wikipedia.org/wiki/Unicode
- https://docs.python.org/3/library/stdtypes.html
- https://kodi.wiki/view/Special_protocol
- https://github.com/xbmc/xbmc/blob/20.1-Nexus/xbmc/interfaces/legacy/ModuleXbmcvfs.h#L170-L197
- https://github.com/xbmc/xbmc/blob/20.1-Nexus/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp#L61-L67
- https://github.com/xbmc/xbmc/blob/20.1-Nexus/xbmc/filesystem/SpecialProtocol.h
- https://github.com/xbmc/xbmc/blob/20.1-Nexus/xbmc/filesystem/SpecialProtocol.cpp#L108
- https://github.com/xbmc/xbmc/blob/20.1-Nexus/xbmc/filesystem/SpecialProtocol.cpp#L119

---

Example error, fixed in this commit.

```text
EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
- NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
Error Type: <class 'UnicodeEncodeError'>
Error Contents: 'ascii' codec can't encode character '\xe5' in position 77: ordinal not in range(128)
Traceback (most recent call last):
 File "/home/user/.kodi/addons/plugin.video.putio/main.py", line 217, in <module>
   main()
 File "/home/user/.kodi/addons/plugin.video.putio/main.py", line 211, in main
   play(item=item)
 File "/home/user/.kodi/addons/plugin.video.putio/main.py", line 157, in play
   li.setSubtitles(item.subtitles())
                   ^^^^^^^^^^^^^^^^
 File "/home/user/.kodi/addons/plugin.video.putio/resources/lib/putio.py", line 209, in subtitles
   self._download_subtitle(subtitle_url, subtitle_path)
 File "/home/user/.kodi/addons/plugin.video.putio/resources/lib/putio.py", line 216, in _download_subtitle
   with open(special_path_translated, 'wb') as f:
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'ascii' codec can't encode character '\xe5' in position 77: ordinal not in range(128)
-->End of Python script error report<--

Playlist Player: skipping unplayable item: 0, path [plugin://plugin.video.putio/?action=play&item=1234567890]
```

</details>