### PR TITLE
Check for status OK instead of status_code 200

### DIFF
--- a/resources/lib/putio.py
+++ b/resources/lib/putio.py
@@ -186,7 +186,7 @@ class _File(_BaseResource):
         """
         subtitles_list_url = '/files/%s/subtitles' % self.id
         subtitles_list_response = self.client.request(subtitles_list_url)
-        assert subtitles_list_response.status_code == 200
+        assert subtitles_list_response['status'] == 'OK'
         # NOTE: The subtitle key (used below) is a bunch of base64 encoded bits. They are not
         # deterministic, and may change even if the video id and each subtitle file contents
         # stays the same. Deleting any previous temporary subtitle files (for all videos) to


### PR DESCRIPTION
- Changes request/response status assertion for subtitle endpoint.
- Fixes crash when starting a video.
- Fix confirmed on putio-kodi v3.1.0, Kodi v20.5.0, Debian 12, Raspberry Pi (aarch64/arm64).

Fixes #16.

See

- https://github.com/putdotio/putio-kodi/issues/16

```text
error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                  - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                 Error Type: <class 'AttributeError'>
                 Error Contents: 'dict' object has no attribute 'status_code'
                 Traceback (most recent call last):
                   File "/home/_kodi/.kodi/addons/plugin.video.putio/main.py", line 205, in <module>
                     main()
                   File "/home/_kodi/.kodi/addons/plugin.video.putio/main.py", line 199, in main
                     play(item=item)
                   File "/home/_kodi/.kodi/addons/plugin.video.putio/main.py", line 135, in play
                     li.setSubtitles(item.subtitles())
                                     ^^^^^^^^^^^^^^^^
                   File "/home/_kodi/.kodi/addons/plugin.video.putio/resources/lib/putio.py", line 189, in subtitles
                     assert subtitles_list_response.status_code == 200
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 AttributeError: 'dict' object has no attribute 'status_code'
                 -->End of Python script error report<--

error <general>: Playlist Player: skipping unplayable item: 0, path [plugin://plugin.video.putio/?action=play&item=00000000000]
```